### PR TITLE
Integrate gutenberg-mobile release 1.51.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.50.1'
+    ext.gutenbergMobileVersion = '236-b4c46731bd0d7529c4df45cbb4ebc23d5c4f769c'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.51.0 release of gutenberg-mobile.  
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/dcalhoun/gutenberg-mobile/pull/236

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.